### PR TITLE
Adjusted keys in degradationEOL input

### DIFF
--- a/src/FINALES2_schemas/classes_common/battery_chemistry.py
+++ b/src/FINALES2_schemas/classes_common/battery_chemistry.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field
 from .formulation_component import FormulationComponent
 from .electrode import Electrode
+from typing import Optional
 
 class BatteryChemistry(BaseModel):
     """A description of the chemistry of a cell.
@@ -9,9 +10,11 @@ class BatteryChemistry(BaseModel):
         description = ("The definition of the composition of the electrolyte used in the "
                      "cells, for which the prediction shall be made")
     )
-    anode:Electrode = Field(
+    anode:Optional[Electrode] = Field(
+        default=None,
         description=("The definition of the anode.")
     )
-    cathode:Electrode = Field(
+    cathode:Optional[Electrode] = Field(
+        default=None,
         description=("The definition of the cathode.")
     )

--- a/src/FINALES2_schemas/classes_output/density/minimal_output.py
+++ b/src/FINALES2_schemas/classes_output/density/minimal_output.py
@@ -13,12 +13,6 @@ class DensityOutput(BaseModel):
         description=("The values determined for the density. "
                      f"Unit: {str(unit_registry.g * unit_registry.cm ** -3)}")
     )
-    temperature: Optional[float] = Field(
-        default=None,
-        unit=str(unit_registry.kelvin),
-        description=("This is the actual temperature of measuring cell. "
-                     f"Unit: {str(unit_registry.kelvin)}")
-    )
     meta:MethodMeta = Field(
         description=("This field provides information regarding the reliability of the "
                      "reported data. E.g. the success of the method for this quantity "
@@ -27,4 +21,10 @@ class DensityOutput(BaseModel):
                      "quantities. It is not included in the RunInfo as one run may "
                      "generate data for different quantities, for which the methods "
                      "may fail individually.")
+    )
+    temperature: Optional[float] = Field(
+        default=None,
+        unit=str(unit_registry.kelvin),
+        description=("This is the actual temperature of measuring cell. "
+                     f"Unit: {str(unit_registry.kelvin)}")
     )


### PR DESCRIPTION
- Electrodes are now optional in the degradationEOL input to enable requests only focusing on the electrolyte
- in the density input, the optional keys are now at the bottom of the file